### PR TITLE
fix: Use the platform display name for folders

### DIFF
--- a/macos/Multifolder/Extensions/URL.swift
+++ b/macos/Multifolder/Extensions/URL.swift
@@ -22,10 +22,8 @@ import Foundation
 
 extension URL {
 
-    var lastPathComponent: String {
-        get {
-            (absoluteString as NSString).lastPathComponent
-        }
+    var displayName: String {
+        FileManager.default.displayName(atPath: self.path)
     }
 
 }

--- a/macos/Multifolder/SmartFolderView.swift
+++ b/macos/Multifolder/SmartFolderView.swift
@@ -35,7 +35,7 @@ struct SmartFolderView: View {
                 ForEach(folder.paths) { link in
                     HStack {
                         IconView(url: link, size: CGSize(width: 16, height: 16))
-                        Text(link.lastPathComponent)
+                        Text(link.displayName)
                     }
                     .contextMenu {
                         Button("Remove") {


### PR DESCRIPTION
Previously we were using the lastPathComponent of the URL which would use URL encoding for spaces and URL-unsafe characters. This change switches to using the FileManager `displayName` method which is guaranteed to give the dislay names as users see them.