### PR TITLE
ci: Only notarize release branch builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,10 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
+    - name: Trust the GitHub SSH keys
+      run: |
+        for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
+
     - name: Install Pipenv
       run: |
         sudo pip3 install pipenv
@@ -30,20 +34,16 @@ jobs:
     - name: Install dependencies
       run: scripts/install-dependencies.sh
 
-    - name: Trust the GitHub SSH keys
-      run: |
-        for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
-
     - name: Build and test
       env:
         TEMPORARY_KEYCHAIN_PASSWORD: ${{ secrets.TEMPORARY_KEYCHAIN_PASSWORD }}
         MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
         CERTIFICATE_REPOSITORY: ${{ secrets.CERTIFICATE_REPOSITORY }}
         CERTIFICATE_REPOSITORY_AUTHORIZATION_KEY: ${{ secrets.CERTIFICATE_REPOSITORY_AUTHORIZATION_KEY }}
-        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
         FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NOTARIZE: ${{ github.ref == 'refs/heads/main' }}
         TRY_RELEASE: ${{ github.ref == 'refs/heads/main' }}
       run: scripts/build.sh
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,79 @@
 Utility for adding multiple folders to macOS Smart Folders
 
 ![Screenshot of Multifolder editing a Smart Folder](images/screenshot.png)
+
+## Development
+
+### Managing Certificates
+
+The build script (details below) uses Fastlane's match task to manage a certificates and a local keychain. Unfortunately, match seems very buggy when using Developer ID certificates, meaning it can't safely be used to fetch the certificates from Apple (it will keep creating new developer certificates until you reach your quota).
+
+Instead, you can manually import a manually created certificate and private keychain into an existing match certificate store:
+
+```bash
+fastlane match import --skip_certificate_matching true --type developer_id
+```
+
+Match will ask for the path to your certificate (`.cer`) and private key file (`.p12`).
+
+N.B. When manually importing certificates, match will not generate file names with identifiers so it's a good idea to name the certificate and private key with a matching, and obvious name.
+
+### Builds
+
+In order to make continuous integration easy the `scripts/build.sh` script builds the full project, including submitting the macOS app for notarization. In order to run this script (noting that you probably don't want to use it for regular development cycles), you'll need to configure your environment accordingly, by setting the following environment variables:
+
+- `MATCH_PASSWORD` -- the password/passphrase to secure the [match](https://docs.fastlane.tools/actions/match/) certificate store
+- `CERTIFICATE_REPOSITORY` -- the repository used for the match certificate store (must be HTTPS)
+- `CERTIFICATE_REPOSITORY_AUTHORIZATION_KEY` -- a GitHub authorization key used to access the certificate repository (see the [match authorization docs](https://docs.fastlane.tools/actions/match/#git-storage-on-github))
+- `APPLE_DEVELOPER_ID` -- individual Apple Developer Account ID (used for notarization)
+- `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD` -- [app-specific password](https://support.apple.com/en-us/HT204397) for the Developer Account
+- `NOTARIZE` -- boolean indicating whether to attempt notarize the build (conditionally set based on the current branch using `${{ github.ref == 'refs/heads/main' }}`)
+- `TRY_RELEASE` -- boolean indicating whether to attempt a release (conditionally set based on the current branch using `${{ github.ref == 'refs/heads/main' }}`)
+- `GITHUB_TOKEN` -- [GitHub token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) used to create the release
+
+The script (like Fastlane) will look for and source an environment file in the Fastlane directory (`Fastlane/.env`) which you can add your local details to. This file is, of course, in `.gitignore`. For example,
+
+```bash
+# Certificate store
+export MATCH_PASSWORD=
+export CERTIFICATE_REPOSITORY=
+export CERTIFICATE_REPOSITORY_AUTHORIZATION_KEY=
+
+# Developer account
+export APPLE_DEVELOPER_ID=
+export FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD=
+
+# GitHub (only required if publishing releases locally)
+export GITHUB_TOKEN=
+
+# Release
+export TRY_RELEASE=false
+```
+
+You can generate your GitHub authorization key (for `CERTIFICATE_REPOSITORY_AUTHORIZATION_KEY`) as follows:
+
+```bash
+echo -n your_github_username:your_personal_access_token | base64
+```
+
+Once you've added your environment variables to this, run the script from the root of the project directory as follows:
+
+```bash
+./scripts/build.sh
+```
+
+You can notarize local builds by specifying the `--notarize` parameter:
+
+```bash
+./scripts/build.sh --notarize
+```
+
+You can publish a build locally by specifying the `--release` parameter:
+
+```bash
+./scripts/build.sh --release
+```
+
+## Licensing
+
+Multifolder is licensed under the MIT License (see [LICENSE](LICENSE)).

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,14 +41,14 @@ BUILD_TOOLS_SCRIPT="${SCRIPTS_DIRECTORY}/build-tools/build-tools"
 
 # Process the command line arguments.
 POSITIONAL=()
-NOTARIZE=true
+NOTARIZE=${NOTARIZE:-false}
 RELEASE=false
 while [[ $# -gt 0 ]]
 do
     key="$1"
     case $key in
-        -N|--skip-notarize)
-        NOTARIZE=false
+        -n|--notarize)
+        NOTARIZE=true
         shift
         ;;
         -r|--release)


### PR DESCRIPTION
This change disables the notarization step by default, adds an explicit `--notarize` flag for local builds, and honours the `NOTARIZE` environment variable which is now set by the GitHub Actions workflow.

This change also adds documentation for the full build and release process.