### PR TITLE
ci: Simplify the build script by using the new changes --exec parameter

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -168,6 +168,6 @@ if $RELEASE ; then
         release \
         --skip-if-empty \
         --push \
-        --command "\"${CHANGES_GITHUB_RELEASE_SCRIPT}\" \"\$@\"" \
+        --command "${CHANGES_GITHUB_RELEASE_SCRIPT}" \
         "${BUILD_DIRECTORY}/${ZIP_BASENAME}"
 fi


### PR DESCRIPTION
The latest version of the changes script adds an alternative to the `--command` parameter when performing releases that obviates the need to explicitly handle the arguments in the inline script, executing the binary directly. This change catches up to that new version and takes advantage of this to simplify the build script.