### PR TITLE
ci: Update the changes call to use the --exec parameter

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -168,6 +168,6 @@ if $RELEASE ; then
         release \
         --skip-if-empty \
         --push \
-        --command "${CHANGES_GITHUB_RELEASE_SCRIPT}" \
+        --exec "${CHANGES_GITHUB_RELEASE_SCRIPT}" \
         "${BUILD_DIRECTORY}/${ZIP_BASENAME}"
 fi


### PR DESCRIPTION
The call to `changes release` was updated with the intention of using the new `--exec` parameter, but mistakenly left using `--command` meaning the files to release were not being correctly passed to the GitHub release command.